### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/color_util/CMakeLists.txt
+++ b/color_util/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(color_util PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(color_util
+target_link_libraries(color_util PUBLIC
   std_msgs
 )
 


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
